### PR TITLE
[cubestore] setup RWX storage class as default for remoteDir

### DIFF
--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -85,7 +85,7 @@ remoteDir:
     ## Persistent Volume access modes
     ##
     accessModes:
-      - ReadWriteOnce
+      - ReadWriteMany
 
     ## @param remoteDir.persistence.storageClass The storage class to use for the remoteDir pvc
     ## If defined, storageClassName: <storageClass>


### PR DESCRIPTION
Signed-off-by: František Hána <sinacek@gmail.com>