### PR TITLE
[cube] fix chart version

### DIFF
--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Cube
 home: https://cube.dev
 type: application
 version: 1.3.0
-appVersion: " 0.32.7"
+appVersion: "0.32.7"
 keywords:
   - cubejs
   - cube


### PR DESCRIPTION
Solves problem 
```
Error: Service "cube" is invalid: metadata.labels: Invalid value: " 0.32.7": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```