### PR TITLE
[cube] Use 'databricks-jdbc' as db type for Databricks

### DIFF
--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -3,7 +3,7 @@ name: cube
 description: A Helm chart for Cube
 home: https://cube.dev
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "0.33.4"
 keywords:
   - cubejs

--- a/charts/cube/templates/_env.tpl
+++ b/charts/cube/templates/_env.tpl
@@ -20,7 +20,7 @@
 {{- if eq $i.type "clickhouse" }}
 {{- include "cube.env.database.clickhouse" (set $i "datasource" $e) }}
 {{- end }}
-{{- if eq $i.type "databricks" }}
+{{- if eq $i.type "databricks-jdbc" }}
 {{- include "cube.env.database.databricks" (set $i "datasource" $e) }}
 {{- end }}
 {{- if eq $i.type "elasticsearch" }}


### PR DESCRIPTION
Related issue: #25 