### PR TITLE
[cubestore] add init-router resource configuration

### DIFF
--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "0.33.4"
 keywords:
   - cube

--- a/charts/cubestore/README.md
+++ b/charts/cubestore/README.md
@@ -209,3 +209,4 @@ By default local dir are not persisted. You can enable persistance on router and
 | `workers.spreadConstraints`                           | Topology spread constraint for pod assignment                                                                       | `[]`              |
 | `workers.resources`                                   | Define resources requests and limits for single Pods                                                                | `{}`              |
 | `workers.service.annotations`                         | Additional custom annotations for workers service                                                                   | `{}`              |
+| `workers.initRouter.resources`                        | Defines resources for init-router initContainer                                                                     | `{}`              |

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -94,6 +94,10 @@ spec:
         - name: init-router
           image: busybox
           command: ['sh', '-c', 'until nc -vz {{ printf "%s-router" (include "cubestore.fullname" .)}} {{ .Values.router.metaPort }}; do echo "Waiting for router"; sleep 2; done;']
+          {{- if .Values.workers.initRouter.resources }}
+          resources:
+            {{- toYaml .Values.workers.initRouter.resources | nindent 12 }}
+          {{- end }}
       volumes:
       {{- if not .Values.workers.persistence.enabled }}
         - name: datadir

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -379,3 +379,10 @@ workers:
   ##     value: "bar"
   ##
   extraEnvVars: []
+
+  ## Configurations for init-router initContainer
+  initRouter:
+    ## Define resources requests and limits for single Pods.
+    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}


### PR DESCRIPTION
Adds resource configurations for `init-router` initContainer. Its needed because of consideration kubernetes makes for initContainers. Kindly check https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources