### PR TITLE
feat: cubestore metrics statsd sidecar container

### DIFF
--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: "0.33.4"
 keywords:
   - cube

--- a/charts/cubestore/README.md
+++ b/charts/cubestore/README.md
@@ -39,7 +39,7 @@ helm upgrade [RELEASE_NAME] gadsme/cubestore --install
 
 ## Configuration
 
-By default a router and two workers will be deployed. You can customize the deployment using helm values.
+By default, a router and two workers will be deployed. You can customize the deployment using helm values.
 
 Refer to the official documentation for more information:
 https://cube.dev/docs/reference/environment-variables#cube-store
@@ -60,23 +60,23 @@ $ helm install my-release \
 gadsme/cubestore
 ```
 
-## Persistance
+## Persistence
 
 ### Remote dir
 
-By default a shared remoteDir is created to store metadata and datasets if no cloudstorage is configured.
+By default, a shared remoteDir is created to store metadata and datasets if no cloudstorage is configured.
 Prefer using cloudStorage if you are running on `gcp` or `aws`.
 
 ### Local dir
 
-By default local dir are not persisted. You can enable persistance on router and master.
+By default, local dir is not persisted. You can enable persistence on router and master.
 
 ## Parameters
 
 ### Common parameters
 
 | Name                | Description                                                  | Value |
-| ------------------- | ------------------------------------------------------------ | ----- |
+|---------------------|--------------------------------------------------------------|-------|
 | `nameOverride`      | Override the name                                            | `""`  |
 | `fullnameOverride`  | Provide a name to substitute for the full names of resources | `""`  |
 | `commonLabels`      | Labels to add to all deployed objects                        | `{}`  |
@@ -85,7 +85,7 @@ By default local dir are not persisted. You can enable persistance on router and
 ### Image parameters
 
 | Name                | Description                                                                             | Value              |
-| ------------------- | --------------------------------------------------------------------------------------- | ------------------ |
+|---------------------|-----------------------------------------------------------------------------------------|--------------------|
 | `image.repository`  | Cubestore image repository                                                              | `cubejs/cubestore` |
 | `image.tag`         | Cubestore image tag (immutable tags are recommended)                                    | `0.32.14`          |
 | `image.pullPolicy`  | Cubestore image pull policy                                                             | `IfNotPresent`     |
@@ -94,7 +94,7 @@ By default local dir are not persisted. You can enable persistance on router and
 ### Global parameters
 
 | Name                       | Description                                                                                                       | Value   |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------|---------|
 | `config.logLevel`          | The logging level for Cube Store                                                                                  | `error` |
 | `config.noUpload`          | If true, prevents uploading serialized pre-aggregations to cloud storage                                          |         |
 | `config.jobRunners`        | The number of parallel tasks that process non-interactive jobs like data insertion, compaction etc. Defaults to 4 |         |
@@ -106,7 +106,7 @@ By default local dir are not persisted. You can enable persistance on router and
 ### Remote dir parameters
 
 | Name                                   | Description                                                                | Value             |
-| -------------------------------------- | -------------------------------------------------------------------------- | ----------------- |
+|----------------------------------------|----------------------------------------------------------------------------|-------------------|
 | `remoteDir.persistence.resourcePolicy` | Setting it to "keep" to avoid removing PVCs during a helm delete operation | `keep`            |
 | `remoteDir.persistence.size`           | Persistent Volume size                                                     | `10Gi`            |
 | `remoteDir.persistence.annotations`    | Additional custom annotations for the PVC                                  | `{}`              |
@@ -116,7 +116,7 @@ By default local dir are not persisted. You can enable persistance on router and
 ### Cloud Storage parameters
 
 | Name                                                | Description                                                                                                            | Value |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----- |
+|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|-------|
 | `cloudStorage.gcp.credentials`                      | A Base64 encoded JSON key file for connecting to Google Cloud. Required when using Google Cloud Storage                |       |
 | `cloudStorage.gcp.credentialsFromSecret.name`       | A Base64 encoded JSON key file for connecting to Google Cloud. Required when using Google Cloud Storage (using secret) |       |
 | `cloudStorage.gcp.credentialsFromSecret.key`        | A Base64 encoded JSON key file for connecting to Google Cloud. Required when using Google Cloud Storage (using secret) |       |
@@ -142,16 +142,16 @@ By default local dir are not persisted. You can enable persistance on router and
 
 ### Metrics
 
-| Name              | Description                                                         | Value |
-| ----------------- | ------------------------------------------------------------------- | ----- |
-| `metrics.format`  | Define which metrics collector format                               |       |
-| `metrics.address` | Required IP address to send metrics                                 |       |
-| `metrics.port`    | Required port to send where collector server accept UDP connections |       |
+| Name              | Description                                                                                                           | Value |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------|-------|
+| `metrics.format`  | Define which metrics collector format. Set it to `statsd` if exporter.enabled is set to `true`                        |       |
+| `metrics.address` | Required IP address to send metrics. Leave it blank if exporter.enabled is set to `true`                              |       |
+| `metrics.port`    | Required port to send where collector server accept UDP connections. Must be set if exporter.enabled is set to `true` |       |
 
 ### Router parameters
 
 | Name                                                 | Description                                                                                                         | Value             |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------|
 | `router.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `false`           |
 | `router.serviceAccount.name`                         | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`              |
 | `router.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                      | `true`            |
@@ -190,7 +190,7 @@ By default local dir are not persisted. You can enable persistance on router and
 ### Workers parameters
 
 | Name                                                  | Description                                                                                                         | Value             |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------|
 | `workers.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `false`           |
 | `workers.serviceAccount.name`                         | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`              |
 | `workers.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                      | `true`            |
@@ -210,3 +210,26 @@ By default local dir are not persisted. You can enable persistance on router and
 | `workers.resources`                                   | Define resources requests and limits for single Pods                                                                | `{}`              |
 | `workers.service.annotations`                         | Additional custom annotations for workers service                                                                   | `{}`              |
 | `workers.initRouter.resources`                        | Defines resources for init-router initContainer                                                                     | `{}`              |
+
+### Statsd exporter parameters
+
+You can enable statsd-prometheus-exporter as sidecar container for router stateful set.
+
+| Name                                   | Description                                                                                                     | Value                       |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `exporter.enabled`                     | Whether statsd-prometheus-exporter will be enabled                                                              | `true`                      |
+| `exporter.image.repository`            | Exporter image repo                                                                                             | `prom/statsd-exporter`      |
+| `exporter.image.tag`                   | Labels to add to all deployed objects                                                                           | `v0.24.0`                   |
+| `exporter.extraArgs`                   | Extra arguments for pass for statsd-prometheus-exporter                                                         | `[]`                        |
+| `exporter.statsd.cacheSize`            | Maximum size of your metric mapping cache                                                                       | `1000`                      |
+| `exporter.statsd.eventQueueSize`       | Size of internal queue for processing events                                                                    | `10000`                     |
+| `exporter.statsd.eventFlushThreshold`  | Number of events to hold in queue before flushing                                                               | `1000`                      |
+| `exporter.statsd.eventFlushInterval`   | Time interval before flushing events in queue                                                                   | `200ms`                     |
+| `exporter.statsd.useDefaultMapping`    | Whether use default mapping. If set to false, you should provide your own configMap with statsd metrics mapping | `true`                      |
+| `exporter.statsd.mappingConfigMapName` | Metrics mapping ConfigMap                                                                                       | `cubestore-metrics-mapping` |
+| `exporter.statsd.mappingConfigMapKey`  | Name of the key inside Metric mapping ConfigMap.                                                                | `statsd.mappingConf`        |
+| `exporter.livenessProbe`               | Liveness probe for exporter container                                                                           | `{ }`                       |
+| `exporter.readinessProbe`              | Readiness probe for exporter container                                                                          | `{ }`                       |
+| `exporter.resources`                   | Resources for exporter container                                                                                | `{ }`                       |
+| `exporter.service.port`                | The address on which to expose the web interface and generated Prometheus metrics container                     | `9102`                      |
+| `exporter.service.path`                | Path under which to expose metrics                                                                              | `/metrics`                  |

--- a/charts/cubestore/templates/router/configmap-statsd-mapping.yml
+++ b/charts/cubestore/templates/router/configmap-statsd-mapping.yml
@@ -1,9 +1,13 @@
-{{- if .Values.exporter.enabled }}
+{{- if and .Values.exporter.enabled .Values.exporter.statsd.useDefaultMapping }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ .Values.exporter.statsd.mappingConfigMapName }}
   labels:
+    {{- include "cubestore.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
     app: statsd-exporter
 data:
   {{ .Values.exporter.statsd.mappingConfigMapKey }}: |

--- a/charts/cubestore/templates/router/service.yaml
+++ b/charts/cubestore/templates/router/service.yaml
@@ -30,6 +30,11 @@ spec:
       port: {{ .Values.router.mysqlPort }}
       targetPort: mysql
     {{- end }}
+    {{- if and .Values.exporter.enabled .Values.exporter.service.port }}
+    - name: http-metrics
+      port: {{ .Values.exporter.service.port }}
+      targetPort: http-metrics
+    {{- end }}
   selector:
     app.kubernetes.io/component: router
     {{- include "cubestore.selectorLabels" . | nindent 4 }}

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "cubestore.selectorLabels" . | nindent 8 }}
         {{- if .Values.commonLabels }}
         {{- toYaml .Values.commonLabels | nindent 8 }}
-        {{- end }}        
+        {{- end }}
       {{- if .Values.commonAnnotations }}
       annotations:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}
@@ -131,15 +131,62 @@ spec:
             - name: remotedir
               mountPath: /cube/data
             {{- end }}
+        {{- if .Values.exporter.enabled }}
+        - name: statsd-exporter
+          image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --web.listen-address=: {{ .Values.exporter.service.port }}
+            - --web.telemetry-path={{ .Values.exporter.service.path }}
+            {{- if .Values.metrics.port }}
+            - --statsd.listen-udp=: {{ .Values.metrics.port }}
+            {{- else }}
+            - --statsd.listen-udp=
+            {{- end }}
+            - --statsd.cache-size={{ .Values.exporter.statsd.cacheSize }}
+            - --statsd.event-queue-size={{ .Values.exporter.statsd.eventQueueSize }}
+            - --statsd.event-flush-threshold={{ .Values.exporter.statsd.eventFlushThreshold }}
+            - --statsd.event-flush-interval={{ .Values.exporter.statsd.eventFlushInterval }}
+            {{- if or .Values.exporter.statsd.mappingConfigMapName .Values.exporter.statsd.mappingConfig }}
+            - --statsd.mapping-config=/etc/prometheus-statsd-exporter/statsd-mapping.conf
+            {{- end }}
+            {{- if .Values.exporter.extraArgs }}
+            {{- toYaml .Values.exporter.extraArgs | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: {{ .Values.exporter.service.port }}
+              protocol: TCP
+            {{- if .Values.metrics.port }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: UDP
+            {{- end }}
+          resources:
+            {{- toYaml .Values.exporter.resources | nindent 12 }}
+          {{- if or .Values.exporter.enabled }}
+          volumeMounts:
+            - name: statsd-mapping-config
+              mountPath: /etc/prometheus-statsd-exporter
+          {{- end }}
+        {{- end }}
       volumes:
       {{- if not .Values.router.persistence.enabled }}
         - name: datadir
-          emptyDir: {}
+          emptyDir: { }
       {{- end }}
       {{- if and (not .Values.cloudStorage.gcp.bucket) (not .Values.cloudStorage.aws.bucket) (not .Values.cloudStorage.minio.bucket) }}
         - name: remotedir
           persistentVolumeClaim:
             claimName: {{ printf "%s-remote-storage" (include "cubestore.fullname" .) }}
+      {{- end }}
+      {{- if or .Values.exporter.enabled }}
+        - name: statsd-mapping-config
+          configMap:
+            name: {{ .Values.exporter.statsd.mappingConfigMapName }}
+            items:
+              - key: {{ .Values.exporter.statsd.mappingConfigMapKey }}
+                path: statsd-mapping.conf
       {{- end }}
       {{- if .Values.router.affinity }}
       affinity:

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -136,10 +136,10 @@ spec:
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --web.listen-address=: {{ .Values.exporter.service.port }}
+            - "--web.listen-address=:{{ .Values.exporter.service.port }}"
             - --web.telemetry-path={{ .Values.exporter.service.path }}
             {{- if .Values.metrics.port }}
-            - --statsd.listen-udp=: {{ .Values.metrics.port }}
+            - "--statsd.listen-udp=:{{ .Values.metrics.port }}"
             {{- else }}
             - --statsd.listen-udp=
             {{- end }}
@@ -147,7 +147,7 @@ spec:
             - --statsd.event-queue-size={{ .Values.exporter.statsd.eventQueueSize }}
             - --statsd.event-flush-threshold={{ .Values.exporter.statsd.eventFlushThreshold }}
             - --statsd.event-flush-interval={{ .Values.exporter.statsd.eventFlushInterval }}
-            {{- if or .Values.exporter.statsd.mappingConfigMapName .Values.exporter.statsd.mappingConfig }}
+            {{- if or .Values.exporter.statsd.mappingConfigMapName }}
             - --statsd.mapping-config=/etc/prometheus-statsd-exporter/statsd-mapping.conf
             {{- end }}
             {{- if .Values.exporter.extraArgs }}

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -136,13 +136,9 @@ spec:
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--web.listen-address=:{{ .Values.exporter.service.port }}"
+            - '--web.listen-address=0.0.0.0:{{ .Values.exporter.service.port }}'
             - --web.telemetry-path={{ .Values.exporter.service.path }}
-            {{- if .Values.metrics.port }}
-            - "--statsd.listen-udp=:{{ .Values.metrics.port }}"
-            {{- else }}
-            - --statsd.listen-udp=
-            {{- end }}
+            - '--statsd.listen-udp=0.0.0.0:{{ .Values.metrics.port }}'
             - --statsd.cache-size={{ .Values.exporter.statsd.cacheSize }}
             - --statsd.event-queue-size={{ .Values.exporter.statsd.eventQueueSize }}
             - --statsd.event-flush-threshold={{ .Values.exporter.statsd.eventFlushThreshold }}

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -160,7 +160,7 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.exporter.resources | nindent 12 }}
-          {{- if or .Values.exporter.enabled }}
+          {{- if .Values.exporter.enabled }}
           volumeMounts:
             - name: statsd-mapping-config
               mountPath: /etc/prometheus-statsd-exporter

--- a/charts/cubestore/templates/router/statsdMap.yml
+++ b/charts/cubestore/templates/router/statsdMap.yml
@@ -1,0 +1,16 @@
+{{- if .Values.exporter.enabled }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Values.exporter.statsd.mappingConfigMapName }}
+  labels:
+    app: statsd-exporter
+data:
+  {{ .Values.exporter.statsd.mappingConfigMapKey }}: |
+    mappings:
+      - match: ".+"
+        match_type: regex
+        name: "$0"
+        labels:
+          statsd_metric_name: "$0"
+{{- end }}

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -64,7 +64,7 @@ config:
   walSplitThreshold:
 
 ## Used to define the shared volume to store metadata and datasets
-## Prefer use cloudStorage if your are running on "gcp" or "aws"
+## Prefer use cloudStorage if you are running on "gcp" or "aws"
 ## If a cloudStorage configuration is used, no remoteDir will be created
 ##
 remoteDir:
@@ -180,9 +180,64 @@ metrics:
   ##
   address:
 
-  ## Required port to send where collector server accept UDP connections
+  ## Required port to send where collector server accepts UDP connections
   ##
   port:
+
+## Configurations for statsd-prometheus-exporter
+##
+exporter:
+  enabled: true
+  image:
+    repository: prom/statsd-exporter
+    tag: "v0.23.3"
+  extraArgs: []
+  statsd:
+    # Maximum size of your metric mapping cache.
+    # Relies on the least recently used replacement policy if max size is reached.
+    cacheSize: 1000
+
+    # Size of internal queue for processing events.
+    eventQueueSize: 10000
+
+    # Number of events to hold in queue before flushing.
+    eventFlushThreshold: 1000
+
+    # Time interval before flushing events in queue.
+    eventFlushInterval: 200ms
+
+    # Metric mapping ConfigMap
+    mappingConfigMapName: cs-metrics
+
+    # Name of the key inside Metric mapping ConfigMap.
+    mappingConfigMapKey: statsd.mappingConf
+
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+
+  resources:
+   requests:
+     cpu: 100m
+     memory: 128Mi
+   limits:
+     cpu: 100m
+     memory: 128Mi
+
+  service:
+    type: ClusterIP
+    # The address on which to expose the web interface and generated Prometheus metrics.
+    port: 9102
+    # Path under which to expose metrics.
+    path: /metrics
+    annotations: {}
 
 router:
   ## Service account for cubestore router to use

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -8,11 +8,11 @@ fullnameOverride: ""
 
 ##  Labels to add to all deployed objects
 ##
-commonLabels: {}
+commonLabels: { }
 
 ## Annotations to add to all deployed objects
 ##
-commonAnnotations: {}
+commonAnnotations: { }
 
 image:
   ## Docker image repository
@@ -32,7 +32,7 @@ image:
   ## Specify a imagePullSecrets
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   ##
-  pullSecrets: []
+  pullSecrets: [ ]
 
 config:
   ## The logging level for Cube Store.
@@ -80,7 +80,7 @@ remoteDir:
 
     ## Additional custom annotations for the PVC
     ##
-    annotations: {}
+    annotations: { }
 
     ## Persistent Volume access modes
     ##
@@ -191,7 +191,7 @@ exporter:
   image:
     repository: prom/statsd-exporter
     tag: "v0.23.3"
-  extraArgs: []
+  extraArgs: [ ]
   statsd:
     # Maximum size of your metric mapping cache.
     # Relies on the least recently used replacement policy if max size is reached.
@@ -224,12 +224,12 @@ exporter:
       port: http
 
   resources:
-   requests:
-     cpu: 100m
-     memory: 128Mi
-   limits:
-     cpu: 100m
-     memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
   service:
     type: ClusterIP
@@ -237,7 +237,7 @@ exporter:
     port: 9102
     # Path under which to expose metrics.
     path: /metrics
-    annotations: {}
+    annotations: { }
 
 router:
   ## Service account for cubestore router to use
@@ -246,7 +246,7 @@ router:
     create: false
     name: ""
     automountServiceAccountToken: true
-    annotations: {}
+    annotations: { }
 
   ## The port for Cube Store to listen to HTTP connections on
   ##
@@ -288,22 +288,22 @@ router:
 
     ## Additional custom annotations for the PVC
     ##
-    annotations: {}
+    annotations: { }
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
-  affinity: {}
+  affinity: { }
 
   ## Topology spread constraint for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   ##
-  spreadConstraints: []
+  spreadConstraints: [ ]
 
   ## Define resources requests and limits for single Pods.
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources: { }
 
   ## Configure options for liveness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
@@ -329,24 +329,24 @@ router:
 
   ##  Custom livenessProbe that overrides the default one
   ##
-  customLivenessProbe: {}
+  customLivenessProbe: { }
 
   ## Custom readinessProbe that overrides the default one
   ##
-  customReadinessProbe: {}
+  customReadinessProbe: { }
 
   ## Tolerations for pod assignment
   ##
-  tolerations: {}
+  tolerations: { }
 
   ## Node selector for pod assignment
   ##
-  nodeSelector: {}
+  nodeSelector: { }
 
   service:
     ## Additional custom annotations for router service
     ##
-    annotations: {}
+    annotations: { }
 
   ## Extra environment variables to pass on to the pod. The value is evaluated as a template
   ## e.g:
@@ -354,7 +354,7 @@ router:
   ##   - name: FOO
   ##     value: "bar"
   ##
-  extraEnvVars: []
+  extraEnvVars: [ ]
 
 workers:
   ## Service account for cubestore workers to use
@@ -363,7 +363,7 @@ workers:
     create: false
     name: ""
     automountServiceAccountToken: true
-    annotations: {}
+    annotations: { }
 
   ## Number of workers to deploy
   ##
@@ -397,35 +397,35 @@ workers:
 
     ## Additional custom annotations for the PVC
     ##
-    annotations: {}
+    annotations: { }
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
-  affinity: {}
+  affinity: { }
 
   ## topology spread constraint for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   ##
-  spreadConstraints: []
+  spreadConstraints: [ ]
 
   ## Define resources requests and limits for single Pods.
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources: { }
 
   ## Tolerations for pod assignment
   ##
-  tolerations: {}
+  tolerations: { }
 
   ## Node selector for pod assignment
   ##
-  nodeSelector: {}
+  nodeSelector: { }
 
   service:
     ## Additional custom annotations for workers service
     ##
-    annotations: {}
+    annotations: { }
 
   ## Extra environment variables to pass on to the pod. The value is evaluated as a template
   ## e.g:
@@ -433,11 +433,11 @@ workers:
   ##   - name: FOO
   ##     value: "bar"
   ##
-  extraEnvVars: []
+  extraEnvVars: [ ]
 
   ## Configurations for init-router initContainer
   initRouter:
     ## Define resources requests and limits for single Pods.
     ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
     ##
-    resources: {}
+    resources: { }

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -132,7 +132,7 @@ cloudStorage:
     ##
     region:
 
-    ## The path in a AWS S3 bucket to store pre-aggregations. Optional
+    ## The path in an AWS S3 bucket to store pre-aggregations. Optional
     ##
     subPath:
 
@@ -190,7 +190,7 @@ exporter:
   enabled: true
   image:
     repository: prom/statsd-exporter
-    tag: "v0.23.3"
+    tag: "v0.24.0"
   extraArgs: [ ]
   statsd:
     # Maximum size of your metric mapping cache.
@@ -206,12 +206,15 @@ exporter:
     # Time interval before flushing events in queue.
     eventFlushInterval: 200ms
 
-    # Metric mapping ConfigMap
-    mappingConfigMapName: cs-metrics
+    # Whether you use default mapping.
+    # If set to false, you should provide your own configMap with statsd metrics mapping.
+    useDefaultMapping: true
+
+    # Metrics mapping ConfigMap
+    mappingConfigMapName: cubestore-metrics-mapping
 
     # Name of the key inside Metric mapping ConfigMap.
     mappingConfigMapKey: statsd.mappingConf
-
 
   livenessProbe:
     httpGet:
@@ -232,12 +235,10 @@ exporter:
       memory: 128Mi
 
   service:
-    type: ClusterIP
     # The address on which to expose the web interface and generated Prometheus metrics.
     port: 9102
     # Path under which to expose metrics.
     path: /metrics
-    annotations: { }
 
 router:
   ## Service account for cubestore router to use
@@ -256,7 +257,7 @@ router:
   ##
   metaPort: 9999
 
-  ## The port for Cube Store to listen to connections on, for example: 3306
+  ## The port for Cube Store to listen to connections on, for example, 3306
   ##
   mysqlPort:
 
@@ -423,12 +424,12 @@ workers:
   nodeSelector: { }
 
   service:
-    ## Additional custom annotations for workers service
+    ## Additional custom annotations for worker service
     ##
     annotations: { }
 
   ## Extra environment variables to pass on to the pod. The value is evaluated as a template
-  ## e.g:
+  ## e.g.:
   ## extraEnvVars:
   ##   - name: FOO
   ##     value: "bar"


### PR DESCRIPTION
Current cubestore metrics implementation support statsd-prometheus-exporter running only in sidecar container mode. Current PR implements optinal enabling this sidecar.