### PR TITLE
[cube] add support for init containers

### DIFF
--- a/charts/cube/README.md
+++ b/charts/cube/README.md
@@ -493,6 +493,7 @@ cubestore:
 | `api.readinessProbe.failureThreshold`             | Success threshold for readinessProbe                                                                                | `3`     |
 | `api.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                                 | `{}`    |
 | `api.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                                | `{}`    |
+| `api.initContainers`                              | Add init containers to load models using volume mounts ( an alternative to using configs, example in values)        | `[]`    |
 
 ### Worker parameters
 

--- a/charts/cube/templates/api/deployment.yaml
+++ b/charts/cube/templates/api/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.api.initContainers }}
+      initContainers: {{- tpl (toYaml .Values.api.initContainers) . | nindent 6 }}
+      {{- end }}
       containers:
         - name: cube
           {{- if .Values.image.tag }}

--- a/charts/cube/values.yaml
+++ b/charts/cube/values.yaml
@@ -575,6 +575,10 @@ api:
 
   apiCount: 1
 
+  ## Init containers to run before starting the main container
+  ##
+  initContainers: []
+
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##

--- a/charts/cube/values.yaml
+++ b/charts/cube/values.yaml
@@ -170,16 +170,26 @@ config:
   ## The config volumes
   ## Will be used to both api and worker
   volumes: []
+  ## In case you want to use configMap
   # - name: schema
   #   configMap:
   #     name: schema
+  ## In case you want to use init container
+  # - name: data-volume
+  #   emptyDir: {}
 
   ## The config volumeMounts
   ## Will be used to both api and worker
   volumeMounts: []
+  ## In case you want to use configMap
   # - name: schema
   #   readOnly: true
   #   mountPath: /cube/conf/schema
+  ## In case you want to use init container
+  # - name: data-volume
+  #   readOnly: true
+  #   mountPath: /cube/conf/schema
+  #   subPath: model
 
 redis:
   ## The host URL for a Redis server
@@ -576,8 +586,17 @@ api:
   apiCount: 1
 
   ## Init containers to run before starting the main container
+  ## We can use an empty volume and volume mounts to copy data
+  ## from a remote location like s3 to the local volume
   ##
   initContainers: []
+  # - name: aws-init-container
+  #   image: amazon/aws-cli:latest
+  #   command: ['sh', '-c', 'aws s3 cp s3://your-s3-bucket/your-data /path/to/volume/mount']
+  #   volumeMounts:
+  #   - name: data-volume
+  #     mountPath: /path/to/volume/mount
+
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
The main idea behind adding init containers is to simplify loading cube files and models into the container using volume mount and sharing that with init container. loading the entire file structure through configs was becoming tedious and will reach limit soon as we can have maximum 1mb. With this i can store all this info in s3 and use aws s3 sync to copy them in init container and then mount the same in main. 

I have a working model, if you think we can add this, will add some documentation as well. 