### PR TITLE
Set the replicas on the router StatefulSet to 1

### DIFF
--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ printf "%s-router" (include "cubestore.fullname" .) }}
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: router


### PR DESCRIPTION
While the default value is 1, setting it explicitly will make sure that if the StatefulSet is scaled to 0 replicas externally, a helm upgrade will reset the value to 1.

This would fix an issue we have in our development environments. We have a process which will scale all Kubernetes workloads to 0 when they are unused. The next time somebody attempts to update the environment (which will do a `helm upgrade`) the chart will fail since the cube-router StatefulSet will not be scaled back to 1 replica. Since the workers have an initContainer that depends on the router, the chart will fail.

I did not make this value configurable because I didn't think there was a use case to have more than 1 replica of the router.