### PR TITLE
[cubestore] add `metaHost` param to customize router hostname

### DIFF
--- a/charts/cubestore/CHANGELOG.md
+++ b/charts/cubestore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The release numbering uses [semantic versioning](http://semver.org).
 
+## 1.1.0
+
+- add metaHost param to customize Cube Store router hostname
+
 ## 1.0.1
 
 - set the replicas on the router StatefulSet to 1

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: "1.2.0"
 keywords:
   - cube

--- a/charts/cubestore/README.md
+++ b/charts/cubestore/README.md
@@ -158,7 +158,7 @@ By default, local dir is not persisted. You can enable persistence on router and
 | `router.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if create is true.                              | `{}`              |
 | `router.httpPort`                                    | The port for Cube Store to listen to HTTP connections on                                                            | `3030`            |
 | `router.metaPort`                                    | The port for the router node to listen for connections on                                                           | `9999`            |
-| `router.metaHost`                                    | Custom hostname for the router service (defaults to "`cubestore.fullname`-router")                                                          | `""`              |
+| `router.metaHost`                                    | Custom hostname for the router service (defaults to "`cubestore.fullname`-router")                                  | `""`              |
 | `router.mysqlPort`                                   | The port for Cube Store to listen to connections on                                                                 |                   |
 | `router.statusPort`                                  | The port for Cube Store to expose status probes                                                                     | `3331`            |
 | `router.extraEnvVars`                                | Extra environment variables to pass on to the pod. The value is evaluated as a template                             | `[]`              |

--- a/charts/cubestore/README.md
+++ b/charts/cubestore/README.md
@@ -158,7 +158,7 @@ By default, local dir is not persisted. You can enable persistence on router and
 | `router.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if create is true.                              | `{}`              |
 | `router.httpPort`                                    | The port for Cube Store to listen to HTTP connections on                                                            | `3030`            |
 | `router.metaPort`                                    | The port for the router node to listen for connections on                                                           | `9999`            |
-| `router.metaHost`                                    | Custom hostname for the router service (defaults to "`cubestore.fullname`-router")                                                          | `""`            |
+| `router.metaHost`                                    | Custom hostname for the router service (defaults to "`cubestore.fullname`-router")                                                          | `""`              |
 | `router.mysqlPort`                                   | The port for Cube Store to listen to connections on                                                                 |                   |
 | `router.statusPort`                                  | The port for Cube Store to expose status probes                                                                     | `3331`            |
 | `router.extraEnvVars`                                | Extra environment variables to pass on to the pod. The value is evaluated as a template                             | `[]`              |

--- a/charts/cubestore/README.md
+++ b/charts/cubestore/README.md
@@ -158,6 +158,7 @@ By default, local dir is not persisted. You can enable persistence on router and
 | `router.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if create is true.                              | `{}`              |
 | `router.httpPort`                                    | The port for Cube Store to listen to HTTP connections on                                                            | `3030`            |
 | `router.metaPort`                                    | The port for the router node to listen for connections on                                                           | `9999`            |
+| `router.metaHost`                                    | Custom hostname for the router service (defaults to "`cubestore.fullname`-router")                                                          | `""`            |
 | `router.mysqlPort`                                   | The port for Cube Store to listen to connections on                                                                 |                   |
 | `router.statusPort`                                  | The port for Cube Store to expose status probes                                                                     | `3331`            |
 | `router.extraEnvVars`                                | Extra environment variables to pass on to the pod. The value is evaluated as a template                             | `[]`              |

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
             - name: CUBESTORE_WORKERS
               value: {{ join "," $workers | quote }}
             - name: CUBESTORE_META_ADDR
-              value: {{ printf "%s-router:%d" (include "cubestore.fullname" .) (.Values.router.metaPort | int) }}
+              value: {{ printf "%s:%d" (default (printf "%s-router" (include "cubestore.fullname" .)) .Values.router.metaHost) (.Values.router.metaPort | int) }}
             - name: CUBESTORE_DATA_DIR
               value: /cube/.cubestore/data
             {{- if and (not .Values.cloudStorage.gcp.bucket) (not .Values.cloudStorage.aws.bucket) (not .Values.cloudStorage.minio.bucket) }}

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -268,6 +268,10 @@ router:
   ##
   metaPort: 9999
 
+  ## Custom hostname for the router service (defaults to "<fullname>-router")
+  ##
+  metaHost: ""
+
   ## The port for Cube Store to listen to connections on, for example, 3306
   ##
   mysqlPort:


### PR DESCRIPTION
Adds a new `router.metaHost` parameter to Cube Store chart to enable hostname customization in `CUBESTORE_META_ADDR`. Defaults to "", which falls back to existing logic.