### PR TITLE
[cube] bump version to capture `scheduledRefreshQueriesPerAppId` addition

### DIFF
--- a/charts/cube/CHANGELOG.md
+++ b/charts/cube/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The release numbering uses [semantic versioning](http://semver.org).
 
+## 3.2.0
+
+- add scheduledRefreshQueriesPerAppId to replace scheduledRefreshConcurrency
+
 ## 3.0.1
 
 - add sidecar support

--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -3,7 +3,7 @@ name: cube
 description: A Helm chart for Cube
 home: https://cube.dev
 type: application
-version: 3.0.1
+version: 3.2.0
 appVersion: "1.2.0"
 keywords:
   - cubejs


### PR DESCRIPTION
Bumping chart version to capture the changes from https://github.com/gadsme/charts/pull/59