### PR TITLE
Add priorityClassName support to Cube and Cubestore charts

### DIFF
--- a/charts/cube/CHANGELOG.md
+++ b/charts/cube/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 The release numbering uses [semantic versioning](http://semver.org).
 
+## 3.4.0
+
+- Add `api.replicaCount` (replaces `api.apiCount`, which is kept as a
+  deprecated alias for backwards compatibility — `replicaCount` wins if
+  both are set).
+- Add `worker.replicaCount`. Previously the worker Deployment hardcoded
+  `replicas: 1`, ignoring all values overrides; now configurable. A
+  HorizontalPodAutoscaler can still take over scaling at runtime.
+
 ## 3.2.0
 
 - add scheduledRefreshQueriesPerAppId to replace scheduledRefreshConcurrency

--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -3,7 +3,7 @@ name: cube
 description: A Helm chart for Cube
 home: https://cube.dev
 type: application
-version: 3.3.0
+version: 3.3.1
 appVersion: "1.5.3"
 keywords:
   - cubejs

--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -3,7 +3,7 @@ name: cube
 description: A Helm chart for Cube
 home: https://cube.dev
 type: application
-version: 3.3.1
+version: 3.4.0
 appVersion: "1.5.3"
 keywords:
   - cubejs

--- a/charts/cube/Chart.yaml
+++ b/charts/cube/Chart.yaml
@@ -3,7 +3,7 @@ name: cube
 description: A Helm chart for Cube
 home: https://cube.dev
 type: application
-version: 3.4.0
+version: 3.5.0
 appVersion: "1.5.3"
 keywords:
   - cubejs

--- a/charts/cube/templates/api/deployment.yaml
+++ b/charts/cube/templates/api/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.api.priorityClassName }}
+      priorityClassName: {{ .Values.api.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/charts/cube/templates/api/deployment.yaml
+++ b/charts/cube/templates/api/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.api.apiCount }}
+  replicas: {{ coalesce .Values.api.replicaCount .Values.api.apiCount 1 }}
   selector:
     matchLabels:
       app.kubernetes.io/component: api

--- a/charts/cube/templates/api/deployment.yaml
+++ b/charts/cube/templates/api/deployment.yaml
@@ -55,6 +55,10 @@ spec:
           image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.apiPort }}

--- a/charts/cube/templates/worker/deployment.yaml
+++ b/charts/cube/templates/worker/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.worker.priorityClassName }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/charts/cube/templates/worker/deployment.yaml
+++ b/charts/cube/templates/worker/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ coalesce .Values.worker.replicaCount 1 }}
   selector:
     matchLabels:
       app.kubernetes.io/component: worker

--- a/charts/cube/templates/worker/deployment.yaml
+++ b/charts/cube/templates/worker/deployment.yaml
@@ -56,6 +56,10 @@ spec:
           image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.apiPort }}

--- a/charts/cube/values.yaml
+++ b/charts/cube/values.yaml
@@ -683,6 +683,10 @@ api:
 
   apiCount: 1
 
+  ## Priority class name for the API pods
+  ##
+  priorityClassName: ""
+
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
@@ -772,6 +776,10 @@ worker:
     name: ""
     automountServiceAccountToken: true
     annotations: {}
+
+  ## Priority class name for the worker pods
+  ##
+  priorityClassName: ""
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/cube/values.yaml
+++ b/charts/cube/values.yaml
@@ -681,7 +681,12 @@ api:
     automountServiceAccountToken: true
     annotations: {}
 
-  apiCount: 1
+  ## Number of API pod replicas. Prefer `replicaCount`; `apiCount` is kept
+  ## as a deprecated alias. If both are set, `replicaCount` wins. Default
+  ## (when neither is set) is 1, supplied by the deployment template via
+  ## `coalesce`.
+  ## replicaCount: 2
+  apiCount: 1  # DEPRECATED — use replicaCount
 
   ## Priority class name for the API pods
   ##
@@ -776,6 +781,11 @@ worker:
     name: ""
     automountServiceAccountToken: true
     annotations: {}
+
+  ## Number of worker pod replicas. Previously hardcoded to 1; now
+  ## configurable. Default (when unset) is 1, supplied by the deployment
+  ## template via `coalesce`. A HorizontalPodAutoscaler can override.
+  ## replicaCount: 2
 
   ## Priority class name for the worker pods
   ##

--- a/charts/cube/values.yaml
+++ b/charts/cube/values.yaml
@@ -57,6 +57,18 @@ securityContext:
   # fsGroup: 1001
   # runAsUser: 1001
 
+## Container Security Context
+## Applied verbatim to the `cube` container in both the api and worker
+## Deployments. Leave empty ({}) to omit. Example hardening:
+##   containerSecurityContext:
+##     allowPrivilegeEscalation: false
+##     readOnlyRootFilesystem: true
+##     capabilities:
+##       drop: ["ALL"]
+##     seccompProfile:
+##       type: RuntimeDefault
+containerSecurityContext: {}
+
 
 config:
   ## The port for a Cube deployment to listen to API connections on

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "1.5.3"
 keywords:
   - cube

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "1.5.3"
 keywords:
   - cube

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.5.3"
 keywords:
   - cube

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 1.2.3
+version: 1.3.0
 appVersion: "1.5.3"
 keywords:
   - cube

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.router.priorityClassName }}
+      priorityClassName: {{ .Values.router.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ template "cubestore.router.serviceAccountName" . }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
           env:
             {{- include "cubestore.common-env" . | nindent 12 }}
             {{- $fullName := include "cubestore.fullname" . }}
-            {{- $headlessServiceName := printf "%s-%s" $fullName "headless" }}
+            {{- $headlessServiceName := printf "%s-%s.%s.svc.cluster.local" $fullName "headless" .Release.Namespace }}
             {{- $workerPort := .Values.workers.port | int }}
             - name: CUBESTORE_SERVER_NAME
               value: {{ printf "%s:%d" (default (printf "%s-router" (include "cubestore.fullname" .)) .Values.router.metaHost) (.Values.router.metaPort | int) }}

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -44,6 +44,10 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
         - name: cubestore
           {{- if .Values.image.tag }}

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -43,6 +43,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- with .Values.securityContext.fsGroupChangePolicy }}
+        fsGroupChangePolicy: {{ . }}
+        {{- end }}
       {{- end }}
       dnsConfig:
         options:

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.workers.priorityClassName }}
+      priorityClassName: {{ .Values.workers.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ template "cubestore.workers.serviceAccountName" . }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -60,7 +60,7 @@ spec:
           env:
             {{- include "cubestore.common-env" . | nindent 12 }}
             {{- $fullName := include "cubestore.fullname" . }}
-            {{- $headlessServiceName := printf "%s-%s" $fullName "headless" }}
+            {{- $headlessServiceName := printf "%s-%s.%s.svc.cluster.local" $fullName "headless" .Release.Namespace }}
             {{- $workerPort := .Values.workers.port | int }}
             - name: MY_POD_NAME
               valueFrom:

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -45,6 +45,10 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
         - name: cubestore
           {{- if .Values.image.tag }}

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- with .Values.securityContext.fsGroupChangePolicy }}
+        fsGroupChangePolicy: {{ . }}
+        {{- end }}
       {{- end }}
       dnsConfig:
         options:

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -278,6 +278,10 @@ router:
     automountServiceAccountToken: true
     annotations: {}
 
+  ## Priority class name for the router pods
+  ##
+  priorityClassName: ""
+
   ## The port for Cube Store to listen to HTTP connections on
   ##
   httpPort: 3030
@@ -406,6 +410,10 @@ workers:
     name: ""
     automountServiceAccountToken: true
     annotations: {}
+
+  ## Priority class name for the worker pods
+  ##
+  priorityClassName: ""
 
   ## Number of workers to deploy
   ##

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -41,6 +41,10 @@ securityContext:
   enabled: false
   #fsGroup:
   #runAsUser:
+  ## fsGroupChangePolicy: set to "OnRootMismatch" to avoid recursively
+  ## re-chowning large data volumes on every pod restart (only chowns when
+  ## the top-level dir ownership doesn't already match fsGroup).
+  #fsGroupChangePolicy: OnRootMismatch
 
 config:
   ## The logging level for Cube Store.


### PR DESCRIPTION
- Add priorityClassName field to api and worker in cube chart
- Add priorityClassName field to router and workers in cubestore chart
- Update deployment/statefulset templates to use priorityClassName when set